### PR TITLE
Release/1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ AudienceStream™ allows you to create a unified view of your customers, correla
 
 ## How To Get Started
 
-* Check out the [Getting Started](https://community.tealiumiq.com/t5/Mobile-Libraries/Tealium-for-Java/ta-p/15325) guide for a step by step walkthrough of adding Tealium to an existing project.  
+* Check out the [Getting Started](https://docs.tealium.com/platforms/java/install/) guide for a step by step walkthrough of adding Tealium to an existing project.  
 * There are many other useful articles at the [Tealium Learning Community](https://community.tealiumiq.com).
 
 ## Contact Us
@@ -27,6 +27,8 @@ AudienceStream™ allows you to create a unified view of your customers, correla
 * If you have **account specific questions** please contact your Tealium account manager
 
 ## Change Log
+- 1.3.1 Persistent Data 
+    - Updated track method to use a copy of Persistent Data to stop event data unexpectedly being stored. 
 - 1.3.0 Remove visitor_id and switch to event endpoint
     - "tealium_visitor_id" and "tealium_vid" removed
     - Use the "event" endpoint using the POST method with json
@@ -72,4 +74,4 @@ Use of this software is subject to the terms and conditions of the license agree
 
 
 ---
-Copyright (C) 2012-2017, Tealium Inc.
+Copyright (C) 2012-2021, Tealium Inc.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tealium</groupId>
     <artifactId>java</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.1</version>
     <name>TealiumJava</name>
     
     <packaging>jar</packaging>
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/tealium/LibraryContext.java
+++ b/src/main/java/com/tealium/LibraryContext.java
@@ -10,7 +10,7 @@ import java.util.Locale;
  * @author Jason Koo, Chad Hartman, Karen Tamayo, Merritt Tidwell, Chris Anderberg
  */
 class LibraryContext {
-    public static final String version = "1.3.0";
+    public static final String version = "1.3.1";
 
     private final String account;
     private final String profile;

--- a/src/main/java/com/tealium/Tealium.java
+++ b/src/main/java/com/tealium/Tealium.java
@@ -108,7 +108,7 @@ public final class Tealium {
                 this.persistentData = new PersistentUdo(new TextStorage(persistentFilePath));
             }
 
-            // set the collect dipatcher if it hasn't been explicitly set with the setCollectDispatcher() method.
+            // set the collect dispatcher if it hasn't been explicitly set with the setCollectDispatcher() method.
             if(this.collectDispatcher == null) {
                 this.collectDispatcher = new CollectDispatcher(CollectDispatcher.DEFAULT_URL, libraryContext, timeout);
             }
@@ -297,7 +297,7 @@ public final class Tealium {
      */
     public void track(String eventType, String eventTitle, Udo eventData, Tealium.DispatchCallback callback) {
 
-        Udo payloadData = this.dataManager.getPersistentData();
+        Udo payloadData = new Udo(this.dataManager.getPersistentData());
 
         if (eventType == null) {
             eventType = EventType.ACTIVITY;

--- a/src/test/java/com/tealium/TealiumTests.java
+++ b/src/test/java/com/tealium/TealiumTests.java
@@ -1,6 +1,5 @@
 package com.tealium;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;


### PR DESCRIPTION
 - Persistent Data fix: new Udo created with a copy of persistent data; stops event data being merged into Persistent data each time.
 - Test coverage for the above issue.
 - Version increment + Changelog
 - Comment typos.